### PR TITLE
Invoice Inquiry selected Account query bug fix

### DIFF
--- a/roles/sales-rep/invoice-inquiry/js/onStartup.js
+++ b/roles/sales-rep/invoice-inquiry/js/onStartup.js
@@ -22,7 +22,7 @@ define(["./invoice.js"], function (invoice) {
             bezl.vars.selectedAccount  = {};
             if (typeof(Storage) !== "undefined" && localStorage.getItem("selectedAccount")) {
                 bezl.vars.selectedAccount  = JSON.parse(localStorage.getItem("selectedAccount"));
-                invoice.runQuery(bezl, 'Accounts');
+                invoice.runQuery(bezl, 'Invoices');
             }
 
         // Set up event handler for selection of customer on account view


### PR DESCRIPTION
This fixes a bug that was noticed.  The bug was in the invoice inquiry, where it would call the accounts query instead of the invoices query if there was a selected account.  